### PR TITLE
docs: improve README and env setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # Your Supabase project URL (found in your Supabase project settings)
 SUPABASE_URL=
 
-# The anon/public API key for your Supabase project (also found in project settings)
-SUPABASE_KEY=
+# The service role key for your Supabase project (found in project settings)
+SUPABASE_SERVICE_KEY=

--- a/README.md
+++ b/README.md
@@ -1,6 +1,27 @@
 # Cube Scraper
 
-Utility scripts for downloading cube store product listings and normalizing them for insertion into Supabase.
+Cube Scraper is a collection of small Python utilities for building a cube
+product index.  The scripts can download listings from several cube stores,
+normalize the data and push it to a Supabase database.  A separate tool keeps
+vendor prices in sync with the database.
+
+## Requirements
+
+- Python 3.9 or newer
+- [Supabase](https://supabase.com) project credentials
+
+Install dependencies with:
+
+```
+pip install -r requirements.txt
+```
+
+Copy `.env.example` to `.env.local` and fill in your credentials:
+
+```
+SUPABASE_URL=<https://your-project.supabase.co>
+SUPABASE_SERVICE_KEY=<service-role-key>
+```
 
 ## Project structure
 
@@ -13,14 +34,33 @@ data/
 
 ## Usage
 
-Fetch products from a Shopify store:
+### 1. Fetch products from a Shopify store
+
+Download all products for a supported store (e.g. `scs`, `cubicle`):
 
 ```
-python src/fetch_stores_products.py scs
+python src/scrap_cubes_from_stores/fetch_stores_products.py scs
 ```
 
-Normalize and upload to Supabase (requires `.env.local` with credentials):
+The script writes `<store>_products.json` to `data/raw/`.
+
+### 2. Normalize and upload to Supabase
+
+After downloading product files, normalize them and upsert into the database:
 
 ```
-python src/add_cubes_to_database.py
+python src/scrap_cubes_from_stores/add_cubes_to_database.py
 ```
+
+### 3. Track vendor prices
+
+Periodically update prices and availability for known vendor links:
+
+```
+python src/price_tracking/fetch_cube_price.py --limit 20 --log
+```
+
+## License
+
+This project is available under the MIT License.  See `LICENSE` for details.
+


### PR DESCRIPTION
## Summary
- document setup and usage for scraping, uploading, and price tracking
- clarify Supabase credentials in `.env.example`

## Testing
- `python -m compileall src`

------
https://chatgpt.com/codex/tasks/task_e_68a5ee082f54832c89b21824af146f2d